### PR TITLE
Let Expect struct specify the error to return

### DIFF
--- a/tpp.go
+++ b/tpp.go
@@ -105,8 +105,8 @@ func Err() Expect {
 	}
 }
 
-// Error returns an Expect with the given error.
-func Error(e error) Expect {
+// ErrWith returns an Expect with the given error.
+func ErrWith(e error) Expect {
 	return Expect{
 		Expected: True(),
 		Err:      true,


### PR DESCRIPTION
This should allow the user of t++ to specify a particular error value when creating an `Expect` struct, with `tpp.Error(myErrVal)` as opposed to the existing `tpp.Err()` which uses a generic test error.

Tested with one case locally.