### PR TITLE
Allow `Times()` for mock calls

### DIFF
--- a/tpp.go
+++ b/tpp.go
@@ -196,7 +196,8 @@ func (e *Expect) Expectorise(mock Mocker) {
 	}
 
 	if e.times != nil {
-		timesMethod := reflect.ValueOf(mock).MethodByName(("Times"))
+		// Not sure how this interacts with the mock.Maybe() above, need a test..?
+		timesMethod := reflect.ValueOf(mock).MethodByName("Times")
 		if !timesMethod.IsValid() {
 			panic("given mock has no Times method")
 		}


### PR DESCRIPTION
This PR is a suggestion to add a way to call `Times` on the underlying mock. 

I was quite torn suggesting this:
`+` This could add a clean bit of API to reduce repetition in your test cases.
`-` This can already be done by having multiple expects be the same thing.
`-` It increases the size of your API.

Please feel free to immediately close this PR!